### PR TITLE
Fix potential array index out of bounds error and note 0 bug

### DIFF
--- a/firmware/midiSolenoidDriver/midiSolenoidDriver.ino
+++ b/firmware/midiSolenoidDriver/midiSolenoidDriver.ino
@@ -14,6 +14,7 @@ byte pinNumbers[] = {3, 4, 23, 24, 20, 21, 5, 6, 7, 8, 9, 10, 11, 12, 13, 25};
 byte MIDI_CHANNEL = 0;
 byte LOWEST_MIDI_NOTE = 0;
 byte incomingByte;
+byte byteNumber = 0;
 byte note;
 byte velocity;
 int action = 2;
@@ -147,26 +148,31 @@ void loop () {
       //delay(1);
       //digitalWrite(pinNumbers[14],LOW);
       action = 1;
-    } else if (incomingByte == 128+ MIDI_CHANNEL) { // note off message starting
+      byteNumber = 1;
+    } else if (incomingByte == 128 + MIDI_CHANNEL) { // note off message starting
       action = 0;
+      byteNumber = 1;
     } else if (incomingByte == 208) { // aftertouch message starting
       //not implemented yet
     } else if (incomingByte == 160) { // polypressure message starting
       //not implemented yet
-    } else if ( (action == 0) && (note == 0) ) { // if we received a "note off", we wait for which note (databyte)
+    } else if ( (action == 0) && (byteNumber == 1) ) { // if we received a "note off", we wait for which note (databyte)
       note = incomingByte;
       playNote(note, 0);
       note = 0;
       velocity = 0;
       action = 2;
-    } else if ( (action == 1) && (note == 0) ) { // if we received a "note on", we wait for the note (databyte)
+      byteNumber = 0;
+    } else if ( (action == 1) && (byteNumber == 1) ) { // if we received a "note on", we wait for the note (databyte)
       note = incomingByte;
-    } else if ( (action == 1) && (note != 0) ) { // ...and then the velocity
+      byteNumber = 2;
+    } else if ( (action == 1) && (byteNumber == 2) ) { // ...and then the velocity
       velocity = incomingByte;
       playNote(note, velocity);
       note = 0;
       velocity = 0;
       action = 0;
+      byteNumber = 0;
     } else {
     }
   }

--- a/firmware/midiSolenoidDriver/midiSolenoidDriver.ino
+++ b/firmware/midiSolenoidDriver/midiSolenoidDriver.ino
@@ -184,7 +184,7 @@ void playNote(byte note, byte velocity) {
   }
 
   //play note if it's in the correct range
-  if ((note >= LOWEST_MIDI_NOTE) and (note <= LOWEST_MIDI_NOTE + 16)) {
+  if ((note >= LOWEST_MIDI_NOTE) and (note < LOWEST_MIDI_NOTE + 16)) {
     digitalWrite(pinNumbers[note - LOWEST_MIDI_NOTE], value);
     //digitalWrite(pinNumbers[12],value);
   }


### PR DESCRIPTION
**Array index out of bounds:**

The old range check was off by one. 

E.g. if note was set to 17 and LOWEST_MIDI_NOTE was set to 1, the next line would try to access element 16 of the pinNumbers array, (while the maximum index is 15).


**Note 0 bug:**

When the Note Range Selection dip switches were set to 0, it was impossible to activate the first mosfet, (Q1). 

This is because the old algorithm relied on the note variable to be greater than 0 if a note had been sent and we were waiting for velocity. 